### PR TITLE
Move from singleton to viewmodel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
 
+    implementation "android.arch.lifecycle:viewmodel:1.1.0"
+    implementation "android.arch.lifecycle:extensions:1.1.0"
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/main/java/com/example/florent/stateexperiment/Injector.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/Injector.kt
@@ -1,7 +1,0 @@
-package com.example.florent.stateexperiment
-
-
-object Injector {
-
-    var presenter : MainPresenter? = null
-}

--- a/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
@@ -20,8 +20,8 @@ class MainActivity : AppCompatActivity(), View {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val networkViewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
-        presenter = MainPresenter(MainRepository(), networkViewModel)
+        val viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
+        presenter = MainPresenter(MainRepository(), viewModel)
 
         presenter.attach(this)
     }

--- a/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.florent.stateexperiment
 
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.View.GONE
@@ -13,28 +14,20 @@ import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity(), View {
 
-    private var presenter: MainPresenter? = null
+    private lateinit var presenter: MainPresenter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        val networkViewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
+        presenter = MainPresenter(MainRepository(), networkViewModel)
 
-        if (Injector.presenter == null) {
-            Injector.presenter = MainPresenter(MainRepository())
-            println("Singleton initialisation")
-        }
-
-        presenter = Injector.presenter
-
-        presenter?.attach(this)
+        presenter.attach(this)
     }
 
     override fun onDestroy() {
-        presenter?.detach()
-        if (isFinishing) {
-            Injector.presenter = null
-        }
+        presenter.detach()
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainActivity.kt
@@ -20,9 +20,7 @@ class MainActivity : AppCompatActivity(), View {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
-        presenter = MainPresenter(MainRepository(), viewModel)
-
+        presenter = ViewModelProviders.of(this).get(MainPresenter::class.java)
         presenter.attach(this)
     }
 

--- a/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
@@ -7,7 +7,7 @@ import io.reactivex.disposables.Disposable
 
 class MainPresenter(
         private val repository: MainRepository,
-        private val observableViewModel: MainViewModel
+        private val viewModel: MainViewModel
 ) {
 
     private var disposable: Disposable? = null
@@ -25,7 +25,7 @@ class MainPresenter(
     }
 
     fun attach(view: View) {
-        disposable = observableViewModel.caching(view.inputs()) {
+        disposable = viewModel.caching(view.inputs()) {
             publish {
                 it.ofType(MainAction.Refresh::class.java)
                         .compose(networkCall(repository))

--- a/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
@@ -4,22 +4,13 @@ import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
-import io.reactivex.observables.ConnectableObservable
-import io.reactivex.subjects.PublishSubject
-import io.reactivex.subjects.Subject
 
 class MainPresenter(
-        private val repository: MainRepository
+        private val repository: MainRepository,
+        private val observableViewModel: MainViewModel
 ) {
 
-    private lateinit var disposable: Disposable
-    private val input: Subject<MainAction> = PublishSubject.create()
-    private val output: ConnectableObservable<MainUiModel>
-
-    init {
-        output = input.publish { it.ofType(MainAction.Refresh::class.java).compose(networkCall(repository)) }
-                .replay(1)
-    }
+    private var disposable: Disposable? = null
 
     companion object {
         fun networkCall(repository: MainRepository): ObservableTransformer<MainAction.Refresh, MainUiModel> {
@@ -34,17 +25,17 @@ class MainPresenter(
     }
 
     fun attach(view: View) {
-        view.inputs().subscribe(input)
-
-        disposable = output
-                .observeOn(AndroidSchedulers.mainThread())
+        disposable = observableViewModel.caching(view.inputs()) {
+            publish {
+                it.ofType(MainAction.Refresh::class.java)
+                        .compose(networkCall(repository))
+            }
+        }.observeOn(AndroidSchedulers.mainThread())
                 .subscribe(view::render)
-
-        output.connect()
     }
 
     fun detach() {
-        disposable.dispose()
+        disposable?.dispose()
     }
 
     interface View {
@@ -61,3 +52,5 @@ sealed class MainUiModel {
     object Refreshing : MainUiModel()
     data class Display(val name: String) : MainUiModel()
 }
+
+class MainViewModel : ObservableViewModel<MainAction, MainUiModel>()

--- a/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
@@ -25,12 +25,11 @@ class MainPresenter(
     }
 
     fun attach(view: View) {
-        disposable = viewModel.caching(view.inputs()) {
-            publish {
-                it.ofType(MainAction.Refresh::class.java)
-                        .compose(networkCall(repository))
+        disposable = viewModel.caching(view.inputs(), ObservableTransformer {
+            it.publish {
+                it.ofType(MainAction.Refresh::class.java).compose(networkCall(repository))
             }
-        }.observeOn(AndroidSchedulers.mainThread())
+        }).observeOn(AndroidSchedulers.mainThread())
                 .subscribe(view::render)
     }
 

--- a/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/MainPresenter.kt
@@ -5,10 +5,10 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 
-class MainPresenter(
-        private val repository: MainRepository,
-        private val viewModel: MainViewModel
-) {
+class MainPresenter : ObservableViewModel<MainAction, MainUiModel>() {
+
+    // This will ideally instantiated through dagger/similar
+    private val repository = MainRepository()
 
     private var disposable: Disposable? = null
 
@@ -24,8 +24,8 @@ class MainPresenter(
         }
     }
 
-    fun attach(view: View) {
-        disposable = viewModel.caching(view.inputs(), ObservableTransformer {
+    fun attach(view: MainPresenter.View): Disposable {
+        return caching(view.inputs(), ObservableTransformer {
             it.publish {
                 it.ofType(MainAction.Refresh::class.java).compose(networkCall(repository))
             }
@@ -51,5 +51,3 @@ sealed class MainUiModel {
     object Refreshing : MainUiModel()
     data class Display(val name: String) : MainUiModel()
 }
-
-class MainViewModel : ObservableViewModel<MainAction, MainUiModel>()

--- a/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
@@ -2,6 +2,7 @@ package com.example.florent.stateexperiment
 
 import android.arch.lifecycle.ViewModel
 import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 
@@ -11,12 +12,12 @@ abstract class ObservableViewModel<Input, Output> : ViewModel() {
 
     fun caching(
             source: Observable<Input>,
-            init: Observable<Input>.() -> Observable<Output>
+            init: ObservableTransformer<Input, Output>
     ): Observable<Output> {
         source.subscribe(input)
 
         if (output == null) {
-            output = input.init().replay(1).autoConnect()
+            output = input.compose(init).replay(1).autoConnect()
         }
 
         return output!!

--- a/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
@@ -10,7 +10,7 @@ abstract class ObservableViewModel<Input, Output> : ViewModel() {
     private val input: Subject<Input> = PublishSubject.create()
     private var output: Observable<Output>? = null
 
-    fun caching(
+    protected fun caching(
             source: Observable<Input>,
             init: ObservableTransformer<Input, Output>
     ): Observable<Output> {

--- a/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
@@ -1,0 +1,34 @@
+package com.example.florent.stateexperiment
+
+import android.arch.lifecycle.ViewModel
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+import io.reactivex.observables.ConnectableObservable
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
+
+abstract class ObservableViewModel<Input, Output> : ViewModel() {
+    private val input: Subject<Input> = PublishSubject.create()
+    private var output: ConnectableObservable<Output>? = null
+
+    private var disposable: Disposable? = null
+
+    fun caching(
+            source: Observable<Input>,
+            init: Observable<Input>.() -> Observable<Output>
+    ): Observable<Output> {
+        source.subscribe(input)
+
+        if (output == null) {
+            output = input.init().replay(1)
+        }
+
+        disposable = output!!.connect()
+        return output!!
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        disposable?.dispose()
+    }
+}

--- a/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
@@ -2,16 +2,12 @@ package com.example.florent.stateexperiment
 
 import android.arch.lifecycle.ViewModel
 import io.reactivex.Observable
-import io.reactivex.disposables.Disposable
-import io.reactivex.observables.ConnectableObservable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 
 abstract class ObservableViewModel<Input, Output> : ViewModel() {
     private val input: Subject<Input> = PublishSubject.create()
-    private var output: ConnectableObservable<Output>? = null
-
-    private var disposable: Disposable? = null
+    private var output: Observable<Output>? = null
 
     fun caching(
             source: Observable<Input>,
@@ -20,15 +16,9 @@ abstract class ObservableViewModel<Input, Output> : ViewModel() {
         source.subscribe(input)
 
         if (output == null) {
-            output = input.init().replay(1)
-            disposable = output!!.connect()
+            output = input.init().replay(1).autoConnect()
         }
 
         return output!!
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        disposable?.dispose()
     }
 }

--- a/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
+++ b/app/src/main/java/com/example/florent/stateexperiment/ObservableViewModel.kt
@@ -21,9 +21,9 @@ abstract class ObservableViewModel<Input, Output> : ViewModel() {
 
         if (output == null) {
             output = input.init().replay(1)
+            disposable = output!!.connect()
         }
 
-        disposable = output!!.connect()
         return output!!
     }
 


### PR DESCRIPTION
This PR moves from the singleton approach to a [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel.html) approach.

The advantage of this is that the state is automatically freed when the activity is terminated, without us having to manage it.

I found out that the logic for keeping that state is actually very generic, so I extracted `ObservableViewModel<Input, Output>` that manages it. The only limitation is that, due to type erasure, we need to extend it and have a named class that we can pass to `ViewModelProviders`, this serves the purpose of having it typed and having a unique key for that view model in the provider.

Benefit of that is that we keep the presenter logic outside of the view model, so we can easily read the implementation inside the presenter 💃 win-win!